### PR TITLE
Avoid processing while the command key is pressed

### DIFF
--- a/AutoRaise.mm
+++ b/AutoRaise.mm
@@ -654,6 +654,14 @@ void onTick() {
 #ifdef ALTERNATIVE_TASK_SWITCHER
     // delayCount = 0 -> warp only
     if (!delayCount) { return; }
+
+    CGEventRef _keyDownEvent = CGEventCreateKeyboardEvent(NULL, 0, true);
+    CGEventFlags keyFlags = CGEventGetFlags(_keyDownEvent);
+    if (_keyDownEvent) { CFRelease(_keyDownEvent); }
+    if (keyFlags & kCGEventFlagMaskCommand) {
+        if (verbose) { NSLog(@"Aborting"); }
+        return;
+    }
 #endif
 
     // delayTicks = 0 -> delay disabled


### PR DESCRIPTION
* This amendment avoids AutoRaise to process while the command key is pressed down
* The usage is written [here](https://dev.to/brisbanewebdeveloper/avoid-autoraise-to-activate-the-window-while-pressing-down-the-command-key-305h)