### PR TITLE
99 introduce new settings

### DIFF
--- a/AutoRaise.mm
+++ b/AutoRaise.mm
@@ -28,7 +28,7 @@
 #include <Carbon/Carbon.h>
 #include <libproc.h>
 
-#define AUTORAISE_VERSION "3.4"
+#define AUTORAISE_VERSION "3.5"
 #define STACK_THRESHOLD 20
 
 #define __MAC_11_06_0 110600
@@ -103,6 +103,7 @@ static bool activated_by_task_switcher = false;
 static AXUIElementRef _accessibility_object = AXUIElementCreateSystemWide();
 static AXUIElementRef _previousFinderWindow = NULL;
 static AXUIElementRef _dock_app = NULL;
+static NSArray * ignoreApps = NULL;
 static const NSString * Dock = @"com.apple.dock";
 static const NSString * Finder = @"com.apple.finder";
 static const NSString * AssistiveControl = @"AssistiveControl";
@@ -114,16 +115,21 @@ static CGPoint desktopOrigin = {0, 0};
 static CGPoint oldPoint = {0, 0};
 static bool spaceHasChanged = false;
 static bool appWasActivated = false;
-static bool mouseStop = false;
+static bool altTaskSwitcher = false;
 static bool warpMouse = false;
 static bool verbose = false;
 static float warpX = 0.5;
 static float warpY = 0.5;
 static float oldScale = 1;
 static float cursorScale = 2;
+static float mouseDelta = 0;
+static int ignoreTimes = 0;
 static int raiseTimes = 0;
 static int delayTicks = 0;
 static int delayCount = 0;
+#ifdef FOCUS_FIRST
+static int raiseDelayCount = 0;
+#endif
 
 //----------------------------------------yabai focus only methods------------------------------------------
 
@@ -607,10 +613,10 @@ static MDWorkspaceWatcher * workspaceWatcher = NULL;
 
 #ifdef FOCUS_FIRST
 - (void)windowFocused:(AXUIElementRef)_window {
-    if (verbose) { NSLog(@"Window focused, waiting %0.3fs", delayCount*POLLING_MS/1000.0); }
+    if (verbose) { NSLog(@"Window focused, waiting %0.3fs", raiseDelayCount*POLLING_MS/1000.0); }
     [self performSelector: @selector(onWindowFocused:)
         withObject: [NSNumber numberWithUnsignedLong: (uint64_t) _window]
-        afterDelay: delayCount*POLLING_MS/1000.0];
+        afterDelay: raiseDelayCount*POLLING_MS/1000.0];
 }
 
 - (void)onWindowFocused:(NSNumber *)_window {
@@ -628,8 +634,15 @@ const NSString *kWarpX = @"warpX";
 const NSString *kWarpY = @"warpY";
 const NSString *kScale = @"scale";
 const NSString *kVerbose = @"verbose";
-const NSString *kMouseStop = @"mouseStop";
-NSArray *parametersDictionary = @[kDelay, kWarpX, kWarpY, kScale, kVerbose, kMouseStop];
+const NSString *kAltTaskSwitcher = @"altTaskSwitcher";
+const NSString *kIgnoreApps = @"ignoreApps";
+const NSString *kMouseDelta = @"mouseDelta";
+#ifdef FOCUS_FIRST
+const NSString *kFocusDelay = @"focusDelay";
+NSArray *parametersDictionary = @[kDelay, kWarpX, kWarpY, kScale, kVerbose, kAltTaskSwitcher, kFocusDelay, kIgnoreApps, kMouseDelta];
+#else
+NSArray *parametersDictionary = @[kDelay, kWarpX, kWarpY, kScale, kVerbose, kAltTaskSwitcher, kIgnoreApps, kMouseDelta];
+#endif
 NSMutableDictionary *parameters = [[NSMutableDictionary alloc] init];
 
 @interface ConfigClass:NSObject
@@ -724,17 +737,24 @@ NSMutableDictionary *parameters = [[NSMutableDictionary alloc] init];
 
 - (void) validateParameters {
     // validate and fix wrong/absent parameters
-    if (!parameters[kDelay]) { parameters[kDelay] = @"1"; }
+#ifdef FOCUS_FIRST
+    if (!parameters[kFocusDelay] && !parameters[kDelay]) {
+#else
+    if (!parameters[kDelay]) {
+#endif
+        parameters[kDelay] = @"1";
+    }
+    if ([parameters[kMouseDelta] floatValue] < 0) { parameters[kMouseDelta] = @"0"; }
     if ([parameters[kScale] floatValue] < 1) { parameters[kScale] = @"2.0"; }
     warpMouse =
         parameters[kWarpX] && [parameters[kWarpX] floatValue] >= 0 && [parameters[kWarpX] floatValue] <= 1 &&
         parameters[kWarpY] && [parameters[kWarpY] floatValue] >= 0 && [parameters[kWarpY] floatValue] <= 1;
-#ifndef FOCUS_FIRST
-    if (![parameters[kDelay] intValue] && !warpMouse) {
-        parameters[kWarpX] = @"0.5";
-        parameters[kWarpY] = @"0.5";
-        warpMouse = true;
-    }
+#ifdef ALTERNATIVE_TASK_SWITCHER
+    if (!parameters[kAltTaskSwitcher]) { parameters[kAltTaskSwitcher] = @"true"; }
+#endif
+#ifdef FOCUS_FIRST
+    if (![parameters[kDelay] intValue] && !parameters[kFocusDelay]) { parameters[kFocusDelay] = @"1"; }
+    if (!parameters[kDelay] && ![parameters[kFocusDelay] intValue]) { parameters[kDelay] = @"1"; }
 #endif
     return;
 }
@@ -749,10 +769,10 @@ void spaceChanged() {
 
 bool appActivated() {
     if (verbose) { NSLog(@"App activated"); }
-#ifndef ALTERNATIVE_TASK_SWITCHER
-    if (!activated_by_task_switcher) { return false; }
-    activated_by_task_switcher = false;
-#endif
+    if (!altTaskSwitcher) {
+        if (!activated_by_task_switcher) { return false; }
+        activated_by_task_switcher = false;
+    }
     appWasActivated = true;
 
     NSRunningApplication *frontmostApp = [[NSWorkspace sharedWorkspace] frontmostApplication];
@@ -783,43 +803,44 @@ bool appActivated() {
         } else { _activatedWindow = _previousFinderWindow; }
     }
 
-#ifdef ALTERNATIVE_TASK_SWITCHER
-    CGEventRef _event = CGEventCreate(NULL);
-    CGPoint mousePoint = CGEventGetLocation(_event);
-    if (_event) { CFRelease(_event); }
+    if (altTaskSwitcher) {
+        CGEventRef _event = CGEventCreate(NULL);
+        CGPoint mousePoint = CGEventGetLocation(_event);
+        if (_event) { CFRelease(_event); }
 
-    bool ignoreActivated = false;
-    AXUIElementRef _mouseWindow = get_mousewindow(mousePoint);
-    if (_mouseWindow) {
-        if (!activated_by_task_switcher) {
-            // Checking for mouse movement reduces the problem of the mouse being warped
-            // when changing spaces and simultaneously moving the mouse to another screen
-            ignoreActivated = fabs(mousePoint.x-oldPoint.x) > 0;
-            ignoreActivated = ignoreActivated || fabs(mousePoint.y-oldPoint.y) > 0;
+        bool ignoreActivated = false;
+        // TODO: is the uncorrected mousePoint good enough?
+        AXUIElementRef _mouseWindow = get_mousewindow(mousePoint);
+        if (_mouseWindow) {
+            if (!activated_by_task_switcher) {
+                // Checking for mouse movement reduces the problem of the mouse being warped
+                // when changing spaces and simultaneously moving the mouse to another screen
+                ignoreActivated = fabs(mousePoint.x-oldPoint.x) > 0;
+                ignoreActivated = ignoreActivated || fabs(mousePoint.y-oldPoint.y) > 0;
+            }
+            if (!ignoreActivated) {
+                // Check if the mouse is already hovering above the frontmost app. If
+                // for example we only change spaces, we don't want the mouse to warp
+                pid_t mouseWindow_pid;
+                ignoreActivated = AXUIElementGetPid(_mouseWindow,
+                    &mouseWindow_pid) == kAXErrorSuccess &&
+                    mouseWindow_pid == frontmost_pid;
+            }
+            CFRelease(_mouseWindow);
+        } else { // dock or top menu
+            // Comment the line below if clicking the dock icons should also
+            // warp the mouse. Note this may introduce some unexpected warps
+            ignoreActivated = true;
         }
-        if (!ignoreActivated) {
-            // Check if the mouse is already hovering above the frontmost app. If
-            // for example we only change spaces, we don't want the mouse to warp
-            pid_t mouseWindow_pid;
-            ignoreActivated = AXUIElementGetPid(_mouseWindow,
-                &mouseWindow_pid) == kAXErrorSuccess &&
-                mouseWindow_pid == frontmost_pid;
+
+        activated_by_task_switcher = false; // used in the previous code block
+
+        if (ignoreActivated) {
+            if (verbose) { NSLog(@"Ignoring app activated"); }
+            if (!finder_app && _activatedWindow) { CFRelease(_activatedWindow); }
+            return false;
         }
-        CFRelease(_mouseWindow);
-    } else { // dock or top menu
-        // Comment the line below if clicking the dock icons should also
-        // warp the mouse. Note this may introduce some unexpected warps
-        ignoreActivated = true;
     }
-
-    activated_by_task_switcher = false; // used in the previous code block
-
-    if (ignoreActivated) {
-        if (verbose) { NSLog(@"Ignoring app activated"); }
-        if (!finder_app && _activatedWindow) { CFRelease(_activatedWindow); }
-        return false;
-    }
-#endif
 
     if (_activatedWindow) {
         if (verbose) { NSLog(@"Warp mouse"); }
@@ -840,14 +861,14 @@ void onTick() {
     float mouse_y_diff = mousePoint.y-oldPoint.y;
     oldPoint = mousePoint;
 
-    bool mouseMoved = fabs(mouse_x_diff) > 0;
-    mouseMoved = mouseMoved || fabs(mouse_y_diff) > 0;
+    bool mouseMoved = fabs(mouse_x_diff) > mouseDelta;
+    mouseMoved = mouseMoved || fabs(mouse_y_diff) > mouseDelta;
 
-#ifdef FOCUS_FIRST
-    if (mouseMoved) { delayTicks = 1; }
-#elif defined ALTERNATIVE_TASK_SWITCHER
     // delayCount = 0 -> warp only
-    if (!delayCount) { return; }
+#ifdef FOCUS_FIRST
+    if (altTaskSwitcher && !delayCount && !raiseDelayCount) { return; }
+#else
+    if (altTaskSwitcher && !delayCount) { return; }
 #endif
 
     // delayTicks = 0 -> delay disabled
@@ -880,7 +901,10 @@ void onTick() {
     }
 #endif
 
-    if (appWasActivated) {
+    if (ignoreTimes) {
+        ignoreTimes--;
+        return;
+    } else if (appWasActivated) {
         appWasActivated = false;
         return;
     } else if (spaceHasChanged) {
@@ -890,14 +914,12 @@ void onTick() {
         raiseTimes = 3;
         delayTicks = 0;
         spaceHasChanged = false;
-#ifndef FOCUS_FIRST
     } else if (delayTicks && mouseMoved) {
         delayTicks = 0;
         // propagate the mouseMoved event
         // to restart the delay if needed
         oldPoint.x = oldPoint.y = 0;
         return;
-#endif
     }
 
     // mouseMoved: we have to decide if the window needs raising
@@ -913,7 +935,7 @@ void onTick() {
             CGEventRef _keyDownEvent = CGEventCreateKeyboardEvent(NULL, 0, true);
             CGEventFlags flags = CGEventGetFlags(_keyDownEvent);
             if (_keyDownEvent) { CFRelease(_keyDownEvent); }
-            abort = (flags & kCGEventFlagMaskCommand) == kCGEventFlagMaskCommand;
+            abort = (flags & kCGEventFlagMaskControl) == kCGEventFlagMaskControl;
         }
 
         if (abort) {
@@ -928,13 +950,18 @@ void onTick() {
             pid_t mouseWindow_pid;
             if (AXUIElementGetPid(_mouseWindow, &mouseWindow_pid) == kAXErrorSuccess) {
                 bool needs_raise = true;
-
-                if (titleEquals(_mouseWindow, @[NoTitle, BartenderBar])) {
+#ifdef FOCUS_FIRST
+                if (delayCount && raiseDelayCount != 1 && titleEquals(_mouseWindow, @[NoTitle])) {
+                    needs_raise = false;
+                    if (verbose) { NSLog(@"Excluding window"); }
+                } else
+#endif
+                if (titleEquals(_mouseWindow, @[BartenderBar])) {
                     needs_raise = false;
                     if (verbose) { NSLog(@"Excluding window"); }
                 } else {
                     AXUIElementRef _mouseWindowApp = AXUIElementCreateApplication(mouseWindow_pid);
-                    if (titleEquals(_mouseWindowApp, @[AssistiveControl])) {
+                    if (titleEquals(_mouseWindowApp, ignoreApps)) {
                         needs_raise = false;
                         if (verbose) { NSLog(@"Excluding app"); }
                     }
@@ -963,19 +990,23 @@ void onTick() {
                             _AXUIElementGetWindow(_focusedWindow, &focusedWindow_id);
                             needs_raise = mouseWindow_id != focusedWindow_id;
 #ifdef FOCUS_FIRST
-                            if (needs_raise) {
-                                needs_raise = raiseTimes || mouseWindow_id != lastFocusedWindow_id;
-                            } else { lastFocusedWindow_id = 0; }
-                            if (delayCount) {
-#endif
-                                needs_raise = needs_raise && !contained_within(_focusedWindow, _mouseWindow);
-#ifdef FOCUS_FIRST
+                            if (delayCount && raiseDelayCount != 1) {
+                                if (needs_raise) {
+                                    needs_raise = raiseTimes || mouseWindow_id != lastFocusedWindow_id;
+                                } else { lastFocusedWindow_id = 0; }
+                                if (raiseDelayCount) {
+                                    needs_raise = needs_raise && !contained_within(_focusedWindow, _mouseWindow);
+                                } else {
+                                    needs_raise = needs_raise && main_window(_focusedWindow);
+                                }
+                                if (needs_raise) {
+                                    OSStatus error = GetProcessForPID(frontmost_pid, &focusedWindow_psn);
+                                    if (!error) { _focusedWindow_psn = &focusedWindow_psn; }
+                                }
                             } else {
-                                needs_raise = needs_raise && main_window(_focusedWindow);
-                            }
-                            if (needs_raise) {
-                                OSStatus error = GetProcessForPID(frontmost_pid, &focusedWindow_psn);
-                                if (!error) { _focusedWindow_psn = &focusedWindow_psn; }
+#endif
+                            needs_raise = needs_raise && !contained_within(_focusedWindow, _mouseWindow);
+#ifdef FOCUS_FIRST
                             }
 #endif
                             CFRelease(_focusedWindow);
@@ -992,30 +1023,26 @@ void onTick() {
                     if (raiseTimes || delayTicks == 1) {
                         delayTicks = 0; // disable delay
 
-                        bool readyForRaise = !mouseStop || !mouseMoved;
-                        if (raiseTimes && readyForRaise) { raiseTimes--; }
+                        if (raiseTimes) { raiseTimes--; }
                         else { raiseTimes = 3; }
-
-                        if (readyForRaise) {
 #ifdef FOCUS_FIRST
-                            if (delayCount != 1) {
-                                OSStatus error = GetProcessForPID(mouseWindow_pid, &mouseWindow_psn);
-                                if (!error) {
-                                    window_manager_focus_window_without_raise(&mouseWindow_psn,
-                                        mouseWindow_id, _focusedWindow_psn, focusedWindow_id);
-                                    if (_lastFocusedWindow) { CFRelease(_lastFocusedWindow); }
-                                    _lastFocusedWindow = _mouseWindow;
-                                    lastFocusedWindow_pid = mouseWindow_pid;
-                                    lastFocusedWindow_id = mouseWindow_id;
-                                    if (delayCount) { [workspaceWatcher windowFocused: _lastFocusedWindow]; }
-                                }
-                            } else {
-#endif
-                                raiseAndActivate(_mouseWindow, mouseWindow_pid);
-#ifdef FOCUS_FIRST
+                        if (delayCount && raiseDelayCount != 1) {
+                            OSStatus error = GetProcessForPID(mouseWindow_pid, &mouseWindow_psn);
+                            if (!error) {
+                                window_manager_focus_window_without_raise(&mouseWindow_psn,
+                                    mouseWindow_id, _focusedWindow_psn, focusedWindow_id);
+                                if (_lastFocusedWindow) { CFRelease(_lastFocusedWindow); }
+                                _lastFocusedWindow = _mouseWindow;
+                                lastFocusedWindow_pid = mouseWindow_pid;
+                                lastFocusedWindow_id = mouseWindow_id;
+                                if (raiseDelayCount) { [workspaceWatcher windowFocused: _lastFocusedWindow]; }
                             }
+                        } else {
 #endif
+                        raiseAndActivate(_mouseWindow, mouseWindow_pid);
+#ifdef FOCUS_FIRST
                         }
+#endif
                     }
                 } else {
                     raiseTimes = 0;
@@ -1038,8 +1065,13 @@ void onTick() {
 
 CGEventRef eventTapHandler(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void *userInfo) {
     static bool commandTabPressed = false;
-    activated_by_task_switcher = activated_by_task_switcher ||
-        (type == kCGEventFlagsChanged && commandTabPressed);
+    if (type == kCGEventFlagsChanged && commandTabPressed) {
+        if (!activated_by_task_switcher) {
+            activated_by_task_switcher = true;
+            ignoreTimes = 3;
+        }
+    }
+
     commandTabPressed = false;
     if (type == kCGEventKeyDown) {
         CGKeyCode keycode = (CGKeyCode) CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode);
@@ -1059,41 +1091,59 @@ int main(int argc, const char * argv[]) {
     @autoreleasepool {
         printf("\nv%s by sbmpost(c) 2022, usage:\n\nAutoRaise\n", AUTORAISE_VERSION);
         printf("  -delay <0=no-raise, 1=no-delay, 2=%dms, 3=%dms, ...>\n", POLLING_MS, POLLING_MS*2);
+#ifdef FOCUS_FIRST
+        printf("  -focusDelay <0=no-focus, 1=no-delay, 2=%dms, 3=%dms, ...>\n", POLLING_MS, POLLING_MS*2);
+#endif
         printf("  -warpX <0.5> -warpY <0.5> -scale <2.0>\n");
-        printf("  -mouseStop <true|false>\n");
+        printf("  -altTaskSwitcher <true|false>\n");
+        printf("  -ignoreApps \"<App1,App2, ...>\"\n");
+        printf("  -mouseDelta <0.1>\n");
         printf("  -verbose <true|false>\n\n");
 
         ConfigClass * config = [[ConfigClass alloc] init];
         [config readConfig: argc];
         [config validateParameters];
 
-        delayCount  = [parameters[kDelay] intValue];
-        warpX       = [parameters[kWarpX] floatValue];
-        warpY       = [parameters[kWarpY] floatValue];
-        cursorScale = [parameters[kScale] floatValue];
-        verbose     = [parameters[kVerbose] boolValue];
-        mouseStop   = [parameters[kMouseStop] boolValue];
+        delayCount      = [parameters[kDelay] intValue];
+        warpX           = [parameters[kWarpX] floatValue];
+        warpY           = [parameters[kWarpY] floatValue];
+        cursorScale     = [parameters[kScale] floatValue];
+        verbose         = [parameters[kVerbose] boolValue];
+        altTaskSwitcher = [parameters[kAltTaskSwitcher] boolValue];
+        mouseDelta      = [parameters[kMouseDelta] floatValue];
+
+        NSMutableArray * ignore;
+        if (parameters[kIgnoreApps]) {
+            ignore = [[NSMutableArray alloc] initWithArray:
+                [parameters[kIgnoreApps] componentsSeparatedByString:@","]];
+        } else { ignore = [[NSMutableArray alloc] init]; }
 
         printf("Started with:\n");
         if (delayCount) {
             printf("  * delay: %dms\n", (delayCount-1)*POLLING_MS);
-        } else {
-#ifdef FOCUS_FIRST
-            printf("  * warp and focus only (no-raise)\n");
-#else
-            printf("  * warp only (no-raise)\n");
-#endif
         }
+#ifdef FOCUS_FIRST
+        if ([parameters[kFocusDelay] intValue]) {
+            raiseDelayCount = delayCount;
+            delayCount = [parameters[kFocusDelay] intValue];
+            printf("  * focusDelay: %dms\n", (delayCount-1)*POLLING_MS);
+        } else { raiseDelayCount = 1; }
+#endif
         if (warpMouse) {
             printf("  * warpX: %.1f, warpY: %.1f, scale: %.1f\n", warpX, warpY, cursorScale);
+            printf("  * altTaskSwitcher: %s\n", altTaskSwitcher ? "true" : "false");
         }
-#ifndef FOCUS_FIRST
-        if (delayCount) {
-#endif
-            printf("  * mouseStop: %s\n", mouseStop ? "true" : "false");
-#ifndef FOCUS_FIRST
+
+        for (id ignoreApp in ignore) {
+            printf("  * ignoreApp: %s\n", [ignoreApp UTF8String]);
         }
-#endif
+        [ignore addObject: AssistiveControl];
+        ignoreApps = [ignore copy];
+
+        if (mouseDelta) {
+            printf("  * mouseDelta: %.1f\n", mouseDelta);
+        }
+
         printf("  * verbose: %s\n", verbose ? "true" : "false");
 #if defined OLD_ACTIVATION_METHOD or defined FOCUS_FIRST or defined ALTERNATIVE_TASK_SWITCHER
         printf("\nCompiled with:\n");
@@ -1130,13 +1180,13 @@ int main(int argc, const char * argv[]) {
         if (verbose) { NSLog(@"Got run loop source: %s", runLoopSource ? "YES" : "NO"); }
 
         workspaceWatcher = [[MDWorkspaceWatcher alloc] init];
-#if !defined ALTERNATIVE_TASK_SWITCHER and !defined FOCUS_FIRST
-        if (delayCount) {
+#ifdef FOCUS_FIRST
+        if (altTaskSwitcher || raiseDelayCount || delayCount) {
+#else
+        if (altTaskSwitcher || delayCount) {
 #endif
-        [workspaceWatcher onTick: [NSNumber numberWithFloat: POLLING_MS/1000.0]];
-#if !defined ALTERNATIVE_TASK_SWITCHER and !defined FOCUS_FIRST
+            [workspaceWatcher onTick: [NSNumber numberWithFloat: POLLING_MS/1000.0]];
         }
-#endif
 
         _dock_app = findDockApplication();
         desktopOrigin = findDesktopOrigin();

--- a/Info.plist
+++ b/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleGetInfoString</key>
     <string>Copyright © 2022 sbmpost</string>
     <key>CFBundleShortVersionString</key>
-    <string>3.4</string>
+    <string>3.5</string>
     <key>CFBundleIconFile</key>
     <string>AutoRaise</string>
     <key>CFBundleName</key>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
-When you hover a window it will be raised to the front (with a delay of your choosing) and gets the focus.  
-There is also an option to warp the mouse to the center of the activated window when using the cmd-tab key
-combination. See also https://stackoverflow.com/questions/98310/focus-follows-mouse-plus-auto-raise-on-mac-os-x
+**AutoRaise**
+
+When you hover a window it will be raised to the front (with a delay of your choosing) and gets the focus. There is also an option to warp
+the mouse to the center of the activated window when using the cmd-tab key combination. See also
+https://stackoverflow.com/questions/98310/focus-follows-mouse-plus-auto-raise-on-mac-os-x
 
 **Quick start**
 
-If you aren't interested in compiling AutoRaise yourself, it is suggested to download the [disk image](https://github.com/sbmpost/AutoRaise/blob/master/AutoRaise.dmg).  
-It contains a signed application bundle and comes with a convenient GUI thanks to [Lothar Haeger](https://github.com/lhaeger/AutoRaise)
+If you aren't interested in compiling AutoRaise, you can download the [disk image](
+https://github.com/sbmpost/AutoRaise/blob/master/AutoRaise.dmg). It contains a signed application bundle and comes with a convenient GUI
+thanks to [Lothar Haeger](https://github.com/lhaeger/AutoRaise). When started, AutoRaise is disabled by default. Right click on the balloon
+icon in the menubar to change the defaults and left click to start AutoRaise. You will see a dialog asking you to enable Accessibility in
+System Preferences.
+
+*Important*: If you see an older AutoRaise item with balloon icon in the Accessibility pane, first remove it **completely** (clicking the
+minus). Then stop and start AutoRaise clicking the balloon icon, and the item should re-appear so that you can properly enable
+Accessibility.
 
 **Compiling AutoRaise**
 
@@ -41,27 +50,43 @@ After making the project, you end up with these two files:
     AutoRaise.app (version without GUI)
 
 The first binary is to be used directly from the command line and accepts parameters. The second binary, AutoRaise.app, can
-be used without a terminal window and relies on the presence of a configuration file. Note that AutoRaise.app runs on the
-background and can only be stopped via "Activity Monitor" or the AppleScript provided near the bottom of this README.
+be used without a terminal window and relies on the presence of a configuration file. AutoRaise.app runs on the background and
+can only be stopped via "Activity Monitor" or the AppleScript provided near the bottom of this README.
 
 **Command line usage:**
 
-    ./AutoRaise -delay 1 -warpX 0.5 -warpY 0.1 -scale 2.5 -mouseStop false
+    ./AutoRaise -delay 1 -focusDelay 0 -warpX 0.5 -warpY 0.1 -scale 2.5 -altTaskSwitcher false -ignoreApps "App1,App2" -mouseDelta 0.1
 
-The delay is specified in units of 50ms and the warp parameters are factors between 0 and 1. If you only would like to use
-the warp feature, simply set delay to 0. When warping the mouse, the scale parameter allows you to specify the mouse cursor
-size. To disable this, set it to the system configured scale (normally 1.0). If no parameters have been specified, AutoRaise
-disables warp and defaults to -delay 1 (i.e. no delay). If the mouseStop flag is set, AutoRaise requires the mouse to stop
-moving for a moment before raising. Responsiveness will be lower but in return you will be able to select top menubar items
-even if there is another application 'in the way'. To pass the command line parameters by means of a file, create either a
-**~/.AutoRaise** file or a **~/.config/AutoRaise/config** file. The file format is as follows:
+*Note*: focusDelay is only supported when compiled with the "EXPERIMENTAL_FOCUS_FIRST" flag.
+
+  - delay: Raise delay, specified in units of 50ms. Disabled if 0. A delay > 1 requires the mouse to stop for a moment before raising.
+
+  - focusDelay: Focus delay, specified in units of 50ms. Disabled if 0. A delay > 1 requires the mouse to stop for a moment before focusing.
+
+  - warpX: A Factor between 0 and 1. Makes the mouse jump horizontally to the activated window. By default disabled.
+
+  - warpY: A Factor between 0 and 1. Makes the mouse jump vertically to the activated window. By default disabled.
+
+  - scale: Enlarge the mouse for a short period of time after warping it. The default is 2.0. To disable set it to 1.0.
+
+  - altTaskSwitcher: Set to true if you use 3rd party tools to switch between applications (other than standard command-tab).
+
+  - ignoreApps: Comma separated list of apps for which you would like to disable focus/raise.
+
+  - mouseDelta: Requires the mouse to move a certain distance. 0.0 = most sensitive whereas higher values decrease sensitivity.
+    
+AutoRaise can read these parameters from a configuration file. To make this happen, create a **~/.AutoRaise** file or a
+**~/.config/AutoRaise/config** file. The format is as follows:
 
     #AutoRaise config file
-    delay=1 
+    delay=1
+    focusDelay=0
     warpX=0.5
     warpY=0.1
     scale=2.5
-    mouseStop=false
+    altTaskSwitcher=false
+    ignoreApps="App1,App2"
+    mouseDelta=0.1
 
 **AutoRaise.app usage:**
 
@@ -104,34 +129,39 @@ If after checking the above you still experience the problem, I encourage you to
 in github. It will be helpful to provide (a small part of) the verbose log, which can be enabled
 like so:
 
-    ./AutoRaise -delay 1 -warpX 0.5 -warpY 0.1 -scale 2.5 -mouseStop false -verbose true
+    ./AutoRaise <parameters you would like to add> -verbose true
 
 The output should look something like this:
 
-    v3.4 by sbmpost(c) 2022, usage:
+    v3.5 by sbmpost(c) 2022, usage:
 
     AutoRaise
       -delay <0=no-raise, 1=no-delay, 2=50ms, 3=100ms, ...>
+      -focusDelay <0=no-focus, 1=no-delay, 2=50ms, 3=100ms, ...>
       -warpX <0.5> -warpY <0.5> -scale <2.0>
-      -mouseStop <true|false>
+      -altTaskSwitcher <true|false>
+      -ignoreApps "<App1,App2, ...>"
+      -mouseDelta <0.1>
       -verbose <true|false>
 
     Started with:
       * delay: 0ms
       * warpX: 0.5, warpY: 0.1, scale: 2.5
-      * mouseStop: false
+      * altTaskSwitcher: false
+      * ignoreApp: App1
+      * ignoreApp: App2
+      * mouseDelta: 0.1
       * verbose: true
 
     Compiled with:
       * OLD_ACTIVATION_METHOD
       * EXPERIMENTAL_FOCUS_FIRST
-      * ALTERNATIVE_TASK_SWITCHER
 
-    2022-05-16 17:55:02.169 AutoRaise[57228:908941] AXIsProcessTrusted: YES
-    2022-05-16 17:55:02.190 AutoRaise[57228:908941] System cursor scale: 1.000000
-    2022-05-16 17:55:02.208 AutoRaise[57228:908941] Got run loop source: YES
-    2022-05-16 17:55:02.209 AutoRaise[57228:908941] Registered app activated selector
-    2022-05-16 17:55:02.251 AutoRaise[57228:908941] Desktop origin (-1280.000000, 0.000000)
+    2022-08-06 00:37:22.187 AutoRaise[64697:2574991] AXIsProcessTrusted: YES
+    2022-08-06 00:37:22.209 AutoRaise[64697:2574991] System cursor scale: 1.000000
+    2022-08-06 00:37:22.225 AutoRaise[64697:2574991] Got run loop source: YES
+    2022-08-06 00:37:22.226 AutoRaise[64697:2574991] Registered app activated selector
+    2022-08-06 00:37:22.273 AutoRaise[64697:2574991] Desktop origin (-1280.000000, 0.000000)
     ...
     ...
 


### PR DESCRIPTION
- Make ALTERNATIVE_TASK_SWITCHER a setting
- Remove deprecated mouseStop setting (because it equals -delay 2)
- Introduce -focusDelay setting
- Fix Cmd-Tab MRU breaking
- Remove warp default behaviour
- Control instead of Command key for disabling
- Add possibility to exclude apps from focus/raise
- Fix Safari fullscreen not raising
- Introduce mouseDelta setting for movement