### PR TITLE
Fixes for release 3.8

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleGetInfoString</key>
     <string>Copyright © 2023 sbmpost</string>
     <key>CFBundleShortVersionString</key>
-    <string>3.7</string>
+    <string>3.8</string>
     <key>CFBundleIconFile</key>
     <string>AutoRaise</string>
     <key>CFBundleName</key>

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ like so:
 
 The output should look something like this:
 
-    v3.7 by sbmpost(c) 2023, usage:
+    v3.8 by sbmpost(c) 2023, usage:
 
     AutoRaise
       -pollMillis <20, 30, 40, 50, ...>


### PR DESCRIPTION
- Fix switching away from desktop window and photos app. Adds calculator app, #137 
- Add partial workaround for JetBrains PyCharm and WebStorm, #131
- Drop focus loop protection as it would seem floating windows are the ones that can't be focused, #80
