### PR TITLE
Fix downloads hiding

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleGetInfoString</key>
     <string>Copyright © 2023 sbmpost</string>
     <key>CFBundleShortVersionString</key>
-    <string>3.8</string>
+    <string>3.9</string>
     <key>CFBundleIconFile</key>
     <string>AutoRaise</string>
     <key>CFBundleName</key>

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ like so:
 
 The output should look something like this:
 
-    v3.8 by sbmpost(c) 2023, usage:
+    v3.9 by sbmpost(c) 2023, usage:
 
     AutoRaise
       -pollMillis <20, 30, 40, 50, ...>


### PR DESCRIPTION
- If Dock is parent app, do not fallback: works for launchpad & downloads grid, #141
- No longer block popup button item, see #82 (OSX update popup is broken anyway)
- No longer block dock item as it is also handled by checking Dock parent app
- Only fallback if the element was the in the chain