### PR TITLE
Ignore mostly offscreen windows to avoid raise loops with tiling WMs

### DIFF
--- a/AutoRaise.mm
+++ b/AutoRaise.mm
@@ -544,6 +544,51 @@ bool contained_within(AXUIElementRef _window1, AXUIElementRef _window2) {
     return contained;
 }
 
+// Window managers like AeroSpace "hide" windows of inactive workspaces by moving
+// them almost entirely offscreen, keeping a ~1px sliver visible in a bottom corner
+// (macOS refuses to place windows fully outside the visible area). Raising such a
+// window switches the workspace, which parks the previously visible window in the
+// same corner, causing an infinite focus/raise loop. Ignore windows with less than
+// OFFSCREEN_MIN_VISIBLE pixels visible on their best screen.
+#define OFFSCREEN_MIN_VISIBLE 4
+bool mostly_offscreen(AXUIElementRef _window) {
+    bool offscreen = false;
+    AXValueRef _size = NULL;
+    AXValueRef _pos = NULL;
+    AXUIElementCopyAttributeValue(_window, kAXSizeAttribute, (CFTypeRef *) &_size);
+    if (_size) {
+        AXUIElementCopyAttributeValue(_window, kAXPositionAttribute, (CFTypeRef *) &_pos);
+        if (_pos) {
+            CGSize cg_size;
+            CGPoint cg_pos;
+            if (AXValueGetValue(_size, kAXValueTypeCGSize, &cg_size) &&
+                AXValueGetValue(_pos, kAXValueTypeCGPoint, &cg_pos)) {
+                // AX coordinates are top-left based; NSScreen frames are
+                // bottom-left based, so flip them relative to the primary screen.
+                float primaryHeight = NSHeight([NSScreen.screens objectAtIndex: 0].frame);
+                NSRect window_rect = NSMakeRect(cg_pos.x, cg_pos.y,
+                    cg_size.width, cg_size.height);
+                NSRect best_intersection = NSZeroRect;
+                for (NSScreen * screen in NSScreen.screens) {
+                    NSRect frame = screen.frame;
+                    NSRect cg_frame = NSMakeRect(NSMinX(frame),
+                        primaryHeight - NSMaxY(frame), NSWidth(frame), NSHeight(frame));
+                    NSRect intersection = NSIntersectionRect(window_rect, cg_frame);
+                    if (NSWidth(intersection) * NSHeight(intersection) >
+                        NSWidth(best_intersection) * NSHeight(best_intersection)) {
+                        best_intersection = intersection;
+                    }
+                }
+                offscreen = NSWidth(best_intersection) < OFFSCREEN_MIN_VISIBLE ||
+                    NSHeight(best_intersection) < OFFSCREEN_MIN_VISIBLE;
+            }
+            CFRelease(_pos);
+        }
+        CFRelease(_size);
+    }
+    return offscreen;
+}
+
 void findDockApplication() {
     NSArray * _apps = [[NSWorkspace sharedWorkspace] runningApplications];
     for (NSRunningApplication * app in _apps) {
@@ -1162,6 +1207,10 @@ void onTick() {
 #ifdef FOCUS_FIRST
                     workaround_for_apps_raising_on_focus = titleEquals(_mouseWindowApp, AppsRaisingOnFocus);
 #endif
+                }
+                if (needs_raise && mostly_offscreen(_mouseWindow)) {
+                    needs_raise = false;
+                    if (verbose) { NSLog(@"Excluding offscreen window"); }
                 }
                 CFRelease(_mouseWindowApp);
                 CGWindowID focusedWindow_id;


### PR DESCRIPTION
## Problem

Tiling window managers like [AeroSpace](https://github.com/nikitabobko/AeroSpace) "hide" windows of inactive workspaces by moving them almost entirely offscreen, keeping a ~1px sliver visible in a bottom corner of the display (macOS refuses to place windows fully outside the visible area).

When the mouse reaches that corner, AutoRaise's hit-test finds the sliver window and raises it. Raising it switches the workspace, which parks the *previously* visible window in the same corner — so AutoRaise immediately raises that one, switching back. The result is an infinite focus/raise loop (rapid workspace flickering) whenever the cursor sits in that corner.

## Fix

Add a `mostly_offscreen()` check: compute the window's visible intersection with each screen (flipping AX top-left coordinates to NSScreen bottom-left ones), and skip raising/focusing any window with fewer than 4px visible on its best-matching screen.

A genuinely usable window is never that close to fully offscreen, so this shouldn't affect normal operation. The check gates `needs_raise`, so it also covers the `EXPERIMENTAL_FOCUS_FIRST` focus-only path.

## Testing

Running this patch on macOS (Darwin 25, Apple Silicon) with AeroSpace + AutoRaise 5.6 (built both stock and with `-DEXPERIMENTAL_FOCUS_FIRST`) since July 2026: the corner loop is gone, and normal focus-follows-mouse behavior is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)