### PR TITLE
Document the official AutoRaise UI contribution path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 AutoRaise
 AutoRaise.out
 AutoRaise.app
+AutoRaise-UI/
 *~

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 **AutoRaise**
 
+## macOS GUI
+
+The official menu bar app, Preferences UI, app bundle, and login-item integration are maintained in the separate [AutoRaise-UI repository](https://github.com/sbmpost/AutoRaise-UI). Submit GUI issues and pull requests there.
+
+The [sbmpost/AutoRaise repository](https://github.com/sbmpost/AutoRaise) is the source of truth for the AutoRaise engine and command-line options. Submit engine issues and pull requests there.
+
 When you hover a window it will be raised to the front (with a delay of your choosing) and gets the focus. There is also an option to warp
 the mouse to the center of the activated window when using the cmd-tab or cmd-grave (backtick) key combination.
 See also [on stackoverflow](https://stackoverflow.com/questions/98310/focus-follows-mouse-plus-auto-raise-on-mac-os-x)


### PR DESCRIPTION
## Summary

- link the official `sbmpost/AutoRaise-UI` repository from the core README
- clarify that GUI issues and pull requests belong in the UI repository
- clarify that engine and command-line issues and pull requests remain in `sbmpost/AutoRaise`
- ignore a nested `AutoRaise-UI/` development checkout

## Why

The project structure made it easy to mistake the core repository for the place to submit GUI changes. This documentation separates ownership so contributors know where each class of change belongs.

## Validation

- verified the README links and repository targets
- verified the branch contains only the README and nested-checkout ignore changes
